### PR TITLE
handle UnicodeDecodeError while reading countries.json.

### DIFF
--- a/src/format_currency/country.py
+++ b/src/format_currency/country.py
@@ -29,8 +29,12 @@ class Country():
 
         data_json_path = os.path.join(os.path.dirname(__file__), 'data', 'countries.json')
         data = None
-        with open(data_json_path) as f:
-            data = json.load(f)
+        try:
+            with open(data_json_path) as f:
+                data = json.load(f)
+        except UnicodeDecodeError as e:
+            with open(data_json_path, encoding = 'utf-8') as f:
+                data = json.load(f)
 
         cached_countries_data = data
         return data

--- a/src/format_currency/format.py
+++ b/src/format_currency/format.py
@@ -2,7 +2,45 @@ import locale
 
 from .country import Country
 
-def format_currency(number, country_code=None, currency_code=None, currency_symbol=None, decimal_separator=None, thousands_separator=None, decimal_places=None, use_current_locale=False):
+def format_currency(number, country_code=None, currency_code=None, currency_symbol=None, decimal_separator=None, thousands_separator=None, decimal_places=None, use_current_locale=False, **kwargs):
+    """
+    Formats a given number as a currency string according to various parameters and optional locale settings.
+    
+    Parameters:
+    - number (float): The numerical value to be formatted.
+    - country_code (str, optional): The country code to determine currency formatting rules. Defaults to None.
+    - currency_code (str, optional): The currency code to determine currency formatting rules. Defaults to None.
+    - currency_symbol (str, optional): The symbol to be used for the currency. Defaults to None.
+    - decimal_separator (str, optional): The character to use as a decimal separator. Defaults to None.
+    - thousands_separator (str, optional): The character to use as a thousands separator. Defaults to None.
+    - decimal_places (int, optional): The number of decimal places to display. Defaults to None.
+    - use_current_locale (bool, optional): Whether to use the current locale settings for formatting. Defaults to False.
+    - kwargs (dict): Additional keyword arguments.
+    
+    Allowed kwargs:
+    - place_currency_symbol_at_end (bool): Whether to place the currency symbol at the end of the formatted number. Default is false.
+    
+    Returns:
+    - str: The formatted currency string.
+    
+    Raises:
+    - TypeError: If unexpected keyword arguments are provided.
+    
+    Notes:
+    - If no formatting options are provided, auto-formatting is determined based on the country or currency code.
+    - Supports special numbering systems for India and China if the country code is 'IN', 'BD', 'NP', 'PK', or 'CN' respectively.
+    """
+    allowed_kwargs = ['place_currency_symbol_at_end']
+    __unexpected_args_provided = []
+    for kwarg in kwargs:
+        if kwarg not in allowed_kwargs:
+            __unexpected_args_provided.append(kwarg)
+    if len(__unexpected_args_provided) > 0:
+        raise TypeError(f"Unexpected keyword argument(s) '{__unexpected_args_provided}'\nAllowed kwargs are {allowed_kwargs}.")
+    
+    # Get the value(s) of kwargs
+    place_currency_symbol_at_end = kwargs.get('place_currency_symbol_at_end', False)
+
     autoformat = True
     indian_numbering_system = False
     china_numbering_system = False
@@ -59,6 +97,8 @@ def format_currency(number, country_code=None, currency_code=None, currency_symb
     formatted_number = formatted_number.replace('.', '_')
     formatted_number = formatted_number.replace(',', thousands_separator)
     formatted_number = formatted_number.replace('_', decimal_separator)
+    if place_currency_symbol_at_end:
+        return f'{formatted_number} {currency_symbol}'.strip()
     return f'{currency_symbol} {formatted_number}'.strip()
 
 


### PR DESCRIPTION
I'm using *Python 3.12.0* and module is giving me the below error. However, my changes fix the error.
```cmd
  File "....\venv\Lib\site-packages\format_currency\format.py", line 21, in format_currency
    country = Country.load_country(country_code)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "....\venv\Lib\site-packages\format_currency\country.py", line 46, in load_country
    data = cls.load_countries_data()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "....\venv\Lib\site-packages\format_currency\country.py", line 33, in load_countries_data
    data = json.load(f)
           ^^^^^^^^^^^^
  File "C:\Users\....\AppData\Local\Programs\Python\Python312\Lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
                 ^^^^^^^^^
  File "C:\Users\....\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 109993: character maps to <undefined>
```